### PR TITLE
fix: Adapt logic for formatting comments as plain text so hash symbols are removed only at the beginning of the line

### DIFF
--- a/internal/yamlutils/yaml_utils.go
+++ b/internal/yamlutils/yaml_utils.go
@@ -62,11 +62,10 @@ func RemoveYamlDocumentSeparators(yamlContent []byte) []byte {
 // Returns:
 //   - string: The cleaned comment string.
 func FormatCommentAsPlainText(comment string) string {
-	comment = strings.ReplaceAll(comment, "#", "")
 	lines := strings.Split(comment, "\n")
 
 	for i, line := range lines {
-		lines[i] = strings.TrimSpace(line)
+		lines[i] = strings.TrimSpace(strings.TrimPrefix(line, "#"))
 	}
 
 	cleanedComment := strings.Join(lines, "\n")

--- a/internal/yamlutils/yaml_utils_test.go
+++ b/internal/yamlutils/yaml_utils_test.go
@@ -118,6 +118,19 @@ func TestFormatCommentAsPlainTextFormatsMultiLineComment(t *testing.T) {
 	assert.Equal(t, expectedFormattedComment, actualFormattedComment)
 }
 
+func TestFormatCommentAsPlainTextOnlyRemovesHashSymbolInTheBeginning(t *testing.T) {
+	t.Parallel()
+
+	multilineComment := `# This is a comment with a # in it
+# This is a comment with an [anchor link](#anchor) in it`
+
+	expectedFormattedComment := "This is a comment with a # in it\nThis is a comment with an [anchor link](#anchor) in it"
+
+	actualFormattedComment := FormatCommentAsPlainText(multilineComment)
+
+	assert.Equal(t, expectedFormattedComment, actualFormattedComment)
+}
+
 func TestReadYamlFilesFromDirectoryWithNoYamlFilesReturnsNoYamlFiles(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #10