### PR TITLE
Add functionality for displaying the version of labdoc #18

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,6 @@ before:
     - "go mod tidy"
 
 builds:
-
   - env:
       - "CGO_ENABLED=0"
     goos:
@@ -15,6 +14,8 @@ builds:
     goarch:
       - "amd64"
       - "arm64"
+    ldflags:
+      - "-s -w -X github.com/erNail/labdoc/cmd.version={{ .Version }}"
 
 # Container Image build
 kos:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ go install github.com/erNail/labdoc
 #### Via Container
 
 ```shell
-docker pull ernail/labdoc:latest
+docker pull ernail/labdoc:<LATEST_GITHUB_RELEASE_VERSION>
 ```
 
 #### From Source

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// This will be set during the build via `-ldflags "-s -w -X github.com/erNail/labdoc/cmd.version={{ .Version }}"`.
+var version = "dev"
+
 // NewRootCmd creates the root command for the CLI application.
 // This command serves as the entry point and parent for all other commands.
 //
@@ -14,9 +17,10 @@ import (
 //   - *cobra.Command: A pointer to the newly created cobra.Command.
 func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "labdoc",
-		Short: "Generate Markdown documentation from GitLab CI/CD Components",
-		Long:  "A CLI tool for generating Markdown documentation from GitLab CI/CD Components",
+		Use:     "labdoc",
+		Short:   "Generate Markdown documentation from GitLab CI/CD Components",
+		Long:    "A CLI tool for generating Markdown documentation from GitLab CI/CD Components",
+		Version: version,
 	}
 
 	filesystem := afero.NewOsFs()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -17,6 +17,17 @@ func TestRootCmdPrintsHelpWithoutError(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRootCmdPrintsVersionWithoutError(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"--version"})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err)
+}
+
 func TestRootCmdCallsGenerateSubcommand(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -34,6 +34,10 @@ tasks:
     cmds:
       - "semantic-release --dry-run"
 
+  test-version-ldflags:
+    cmds:
+      - "go run -ldflags '-s -w -X github.com/erNail/labdoc/cmd.version=v1.2.3' main.go --version"
+
   test-github-actions:
     cmds:
       - "act"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -26,7 +26,11 @@ tasks:
     cmds:
       - "ko build --platform all --local"
 
-  release-test:
+  test-release-goreleaser:
+    cmds:
+      - "goreleaser release --snapshot --clean"
+
+  test-release-semantic-release:
     cmds:
       - "semantic-release --dry-run"
 


### PR DESCRIPTION
Closes #18 

feat: Add functionality to display the current version of labdoc via the `--version` flag
chore: Add tasks for testing goreleaser and semantic-release to the Taskfile
docs: Fix misleading container instructions in README.md